### PR TITLE
fix #31 - Sets escape=False in create_markdown

### DIFF
--- a/ymir/utils/make_post.py
+++ b/ymir/utils/make_post.py
@@ -137,7 +137,7 @@ def main():
     # special rendering
     renderer = GrangeRenderer()
     markdown = mistune.create_markdown(
-        renderer=renderer, plugins=['strikethrough'])
+        renderer=renderer, plugins=['strikethrough'], escape=False)
     html_text = markdown(markdown_text)
     # Post processing of markdown text
     html_text = add_id(html_text)


### PR DESCRIPTION
This will make it possible to use html markup in markdown. 